### PR TITLE
Dev modules rework

### DIFF
--- a/docs/compute-systems/derecho/derecho-modules.md
+++ b/docs/compute-systems/derecho/derecho-modules.md
@@ -1,3 +1,3 @@
-# Derecho Software
+# Derecho Modules
 
 ---8<--- "docs/compute-systems/derecho/derecho-modules-list.md"

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,5 +31,3 @@ You need a CIT password to submit a request. Call **303-497-2400** if you don't 
     This project is hosted on [GitHub](https://github.com/NCAR/HPC-Docs) and your
     [contributions](https://github.com/NCAR/HPC-Docs/blob/main/contributing.md)
     are welcome!
-
-hi from meeting

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -252,7 +252,7 @@ theme:
 
   font:
         text: Poppins
-        code: Regular
+        code: Roboto Mono
 
   highlightjs: true
 

--- a/theme/no_toc.html
+++ b/theme/no_toc.html
@@ -1,5 +1,0 @@
-{% extends "base.html" %}
-
-{% block content %}
-	<div class="md-sidebar" role="main"></div>
-{% endblock %}


### PR DESCRIPTION
Changes:

- Full software list added to HPC software index page
- Modules subpage merged with top level
- Moved Derecho modules list and Casper modules list to their respective tabs in Compute Services and Systems
- Added snipping tags to the software list generation script
- Removed toc experimental file
- Change code font to Roboto Mono for Safari Support