### PR TITLE
Redirect NHUG Page 

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,21 +1,32 @@
 # Contribution Guide
 
-
-
 Welcome to the NCAR HPC Resources GitHub repository!
 
-This guide provides an overview of how to contribute to this documentations and the standards to follow when adding content to this repository. Our goal is to create a comprehensive and user-friendly documentation resource for NCAR's HPC resources.
+This guide provides an overview of how to contribute to this documentations and the standards to follow when adding content to this repository. 
 
 ## Repository Overview
 
-This repository contains technical documentation for NCAR HPC resources. The documentation is written in Markdown, which is then converted to HTML/CSS/JS using the mkdocs static site generator. We have customized the mkdocs-material theme to align with NCAR branding and colors.
+This repository contains technical documentation for NCAR HPC resources. The documentation is written in Markdown, which is then converted to HTML/CSS/JS using the `mkdocs` static site generator. We have customized the `mkdocs-material` theme to align with NCAR branding and colors.
 
 !!! note
+    If you're new to Markdown, you can learn more about it [here](https://www.markdownguide.org/).
     Here is the reference to the [mkdocs-material documentation features](https://squidfunk.github.io/mkdocs-material/reference/).
+
+In general, the repository is organized into the following sections:
+```
+mkdocs.yml        # The configuration file.
+requirements.txt  # The list of Python dependencies.
+theme/
+    ...           # Customized theme files. 
+docs/
+    index.md      # The documentation homepage.
+    ...           # Other markdown pages, images and other docs files.
+readthedocs.yml   # The configuration file for readthedocs hosting.
+```
 
 ## Making Contributions
 
-For modifications, such as a comprehensive revision of a section in the documentation, we recommend fork this repository, and clone the repository to your local machine and working from there.
+For major modifications, such as a comprehensive revision of a section in the documentation or adding a new section, we recommend to fork this repository, and clone the repository to your local machine and working from there.
 
 ### Steps to Contribute
 
@@ -24,21 +35,20 @@ For modifications, such as a comprehensive revision of a section in the document
 2. **Clone the forked repository to your local machine:** This can be done by running the following command in your terminal:
 
     ```bash
-    git clone https://github.com/<YOUR_USERNAME>/hpc-docs-demo.git
+    git clone https://github.com/<YOUR_USERNAME>/HPC-Docs.git
     ```
         Replace `<YOUR_USERNAME>` with your GitHub username.
 
 3. **Create a new branch:** It's a good practice to create a new branch before you start making changes. This can be done by running:
-```bash
-git checkout -b <BRANCH_NAME>
-```
+    ```bash
+    git checkout -b <BRANCH_NAME>
+    ```
     Replace `<BRANCH_NAME>` with a name that gives a hint about the changes you're about to make.
 
-4. **Make your changes:** With your new branch checked out, you can start making changes to the documentation. Remember to save your work regularly.
+4. **Make your changes:** With your new branch checked out, you can start making changes to the documentation. Remember to save your work regularly and commit your changes often.
 
     !!! tip
         You can live preview your changes locally by running `mkdocs serve` in your terminal. For more on this, see [Building the Documentation Locally](#building-the-documentation-locally) section. 
-
 
 5. **Commit your changes:** Once you have made and tested your changes, stage the files you have modified using `git add <file>` or `git add .` to stage all changes. Then, commit your changes with a descriptive message using `git commit -m "<YOUR_COMMIT_MESSAGE>"`.
 
@@ -46,20 +56,21 @@ git checkout -b <BRANCH_NAME>
 
 7. **Submit a Pull Request (PR):** After pushing your changes, go to HPC-Docs github repository, and click on "New pull request". Fill in the necessary details and submit the PR. Once your have submitted the PR, a bunch of automatic workflows will be triggered. readthedocs will build a preview of your document and add it to the PR. This allows you to preview your changes before they are merged into the main branch.
 
-Please note, for larger changes, it's often a good idea to discuss your plans in an issue before investing a lot of time in implementation.
+    !!! danger "Please note, for larger changes, it's often a good idea to discuss your plans in an issue before investing a lot of time in implementation."
 
 #### Building the Documentation Locally
 
 If you want to build the documentation locally to see the changes you've made, you can do so by following these steps:
 
 ##### Create an Environment
-To build the documentation locally, you'll need to install certain dependencies. Although this step is optional, we strongly recommend it. 
+To build the documentation locally and preview it, you'll need to install certain dependencies. Although this step is optional, we strongly recommend it. 
 
 The example provided here utilizes a conda environment, but feel free to use any Python 3 environment of your preference.
 
   ```bash
-  conda env create -f conda.yaml
-  conda activate mkdocs
+  conda create -n mkdocs-env
+  conda activate mkdocs-env
+  pip install -r requirements.txt
   ```
 
 ##### Preview Documentation Locally
@@ -72,7 +83,7 @@ You can preview your documentation locally to make sure that your changes do not
 !!! note
       `--strict` flag will enable strict mode and treat warnings as errors. This is useful to ensure that your changes do not introduce any issues such as new pages that does not exist. 
 
-#### Simple Contributions
+### Simple Contributions <img src="https://raw.githubusercontent.com/squidfunk/mkdocs-material/master/material/templates/.icons/material/pencil.svg" width="20" height="20">
 
 !!! warning
     At this stage, please avoid making any changes using this tool, since it will make changes directly to main branch. 
@@ -81,7 +92,7 @@ If you're looking to make a minor adjustment to our documentation, such as fixin
 
 As you browse our documentation, you'll notice a pencil icon next to the header on each page. This icon is a shortcut to edit the current page. Here's how you can use this feature:
 
-1. Click on the pencil icon to open the editor.
+1. Click on the pencil icon ( <img src="https://raw.githubusercontent.com/squidfunk/mkdocs-material/master/material/templates/.icons/material/pencil.svg" width="20" height="20"> ) at the top right corner of the page to open the GitHub's built-in editor. 
 2. Make your desired changes.
 3. After you've made your changes, be sure to update the commit message. A clear and concise commit message helps us understand your contribution better.
 4. While not mandatory, we recommend renaming the branch for better organization and tracking of changes.

--- a/docs/nhug/upcoming-events.md
+++ b/docs/nhug/upcoming-events.md
@@ -1,1 +1,0 @@
-# NHUG Upcoming Events

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -352,6 +352,9 @@ plugins:
   - minify:
       minify_html: true
   - open-in-new-tab
+  - redirects:
+      redirect_maps:
+        - 'nhug/index.md':'https://nhug.readthedocs.io/en/latest/'
 
 extra:
   social:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -179,9 +179,6 @@ nav:
 
   - NCAR User Group (NHUG):
     - nhug/index.md
-    - Archive of Past Meetings:
-      - nhug/archive/index.md
-    - NHUG Upcoming Events: nhug/upcoming-events.md
 
   - Contributing to the Documentation: contributing.md
 
@@ -354,7 +351,7 @@ plugins:
   - open-in-new-tab
   - redirects:
       redirect_maps:
-        - 'nhug/index.md':'https://nhug.readthedocs.io/en/latest/'
+        'nhug/index.md': 'https://nhug.readthedocs.io/en/latest/'
 
 extra:
   social:

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ mkdocs-git-revision-date-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-glightbox
 mkdocs-open-in-new-tab
+mkdocs-redirects


### PR DESCRIPTION
This PR includes:

* redirected links to NHUG tab to [the NHUG page](https://nhug.readthedocs.io/en/latest/). 
* slightly updated contribution guide. 