### PR TITLE
Fix Contributors Guide link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Welcome to the HPC Documentation Repository!
 ## Contributing
 We welcome contributions to improve the documentation!
 
-Please visit the [Contribution Guide](https://ncar.github.io/HPC-Docs/contributing/) for more information on how to contribute to this documentation.
+Please visit the [Contribution Guide](https://ncar-hpc-docs.readthedocs.io/en/latest/contributing/) for more information on how to contribute to this documentation.
 
 ## License
 


### PR DESCRIPTION
Change link from a non-existent "https://ncar.github.io/HPC-Docs/contributing/" to the correct "https://ncar-hpc-docs.readthedocs.io/en/latest/contributing/"

Fixes #119 