### PR TITLE
adding google site verification HTML for more in-depth link analysis

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -22,6 +22,9 @@ build:
       # the above may generate a dirty git cache for some committed symbolic links - ignore. ref:
       # https://docs.readthedocs.io/en/stable/build-customization.html#avoid-having-a-dirty-git-index
       - git update-index --assume-unchanged theme.yml
+    post_build:
+      - cp docs/googlebb095fa38c4e87cf.html $READTHEDOCS_OUTPUT/html/
+      - ls -lR $READTHEDOCS_OUTPUT/html/
 
 conda:
   environment: conda.yaml

--- a/docs/googlebb095fa38c4e87cf.html
+++ b/docs/googlebb095fa38c4e87cf.html
@@ -1,0 +1,1 @@
+google-site-verification: googlebb095fa38c4e87cf.html


### PR DESCRIPTION
Ref: https://support.google.com/webmasters/answer/9008080#html_verification&zippy=%2Chtml-file-upload

embed the magic google HTML file required to verify site ownership for Google Console link analysis.