### PR TITLE
Fix cisl urls

### DIFF
--- a/docs/allocations/university-allocations/index.md
+++ b/docs/allocations/university-allocations/index.md
@@ -145,9 +145,9 @@ projects.
 typically made within a few days.**
 
 U.S. university researchers who are supported by an NSF award can
-request an initial small allocation of up to 1 million core-hours on Derecho; 
-and up to 2,500 GPU-hours on Derecho for each NSF award. These allocations 
-can be used to complete small projects or to conduct initial runs in 
+request an initial small allocation of up to 1 million core-hours on Derecho;
+and up to 2,500 GPU-hours on Derecho for each NSF award. These allocations
+can be used to complete small projects or to conduct initial runs in
 preparation for submitting a request for a large allocation.
 
 If needed to complete your work, you can request a *one-time supplement*
@@ -171,9 +171,9 @@ here](https://arc.ucar.edu/xras_submit/opportunities).
 *Resources for unsponsored graduate students, postdocs, and new faculty*
 
 A graduate student, post-doctoral researcher, or new faculty member at a
-U.S. university can request a one-time allocation of up to 500,000 Derecho 
-core-hours or 1,500 Derecho GPU-hours. These awards typically support 
-dissertations, help foster early career research, or provide seed resources 
+U.S. university can request a one-time allocation of up to 500,000 Derecho
+core-hours or 1,500 Derecho GPU-hours. These awards typically support
+dissertations, help foster early career research, or provide seed resources
 for pursuing funded research.
 
 An individual can request a new exploratory project at each stage of
@@ -214,7 +214,7 @@ Earth system scientists can request access to NSF NCAR’s
 [Casper data analysis cluster](../../compute-systems/casper/index.md) and the
 [Campaign Storage file system](../../storage-systems/glade/index.md#campaign-storage-project-space)
 to allow them to conduct analyses on data sets curated by
-[NSF NCAR data services](https://www2.cisl.ucar.edu/computing-data/data) and accessible
+[NSF NCAR data services](https://www.cisl.ucar.edu/computing-data/data) and accessible
 via our storage systems.
 
 We are pleased to make Data Analysis allocations available to

--- a/docs/compute-systems/casper/index.md
+++ b/docs/compute-systems/casper/index.md
@@ -195,13 +195,13 @@ Users already familiar with PBS and batch submission may find [Casper-specific P
 
 ## Status
 ### Nodes
-<p align="left"><iframe width="680" height="1100" frameborder="0" src="https://www.cisl.ucar.edu/uss/queues_table/casper_nodes_BSK.html"></iframe></p>
+<p align="left"><iframe width="680" height="1100" frameborder="0" src="https://status.cisl.ucar.edu/uss/queues_table/casper_nodes_BSK.html"></iframe></p>
 
 #### GPU Usage
-<p align="left"><iframe width="680" height="835" frameborder="0" src="https://www.cisl.ucar.edu/uss/queues_table/casper_gpu_status_BSK.html"></iframe></p>
+<p align="left"><iframe width="680" height="835" frameborder="0" src="https://status.cisl.ucar.edu/uss/queues_table/casper_gpu_status_BSK.html"></iframe></p>
 
 ### Queues
-<p align="left"><iframe width="680" height="440" frameborder="0" src="https://www.cisl.ucar.edu/uss/queues_table/casper_queues_BSK.html"></iframe></p>
+<p align="left"><iframe width="680" height="440" frameborder="0" src="https://status.cisl.ucar.edu/uss/queues_table/casper_queues_BSK.html"></iframe></p>
 
 
 <!--  LocalWords:  Casper Derecho

--- a/docs/compute-systems/derecho/index.md
+++ b/docs/compute-systems/derecho/index.md
@@ -132,7 +132,7 @@ Users already familiar with PBS and batch submission may find [Derecho-specific 
 ##  Status
 
 ### Nodes
-<p align="left"><iframe width="680" height="650" frameborder="0" src="https://www.cisl.ucar.edu/uss/queues_table/derecho_nodes.html"></iframe></p>
+<p align="left"><iframe width="680" height="650" frameborder="0" src="https://status.cisl.ucar.edu/uss/queues_table/derecho_nodes.html"></iframe></p>
 
 ### Queues
-<p align="left"><iframe width="680" height="440" frameborder="0" src="https://www.cisl.ucar.edu/uss/queues_table/derecho_queues.html"></iframe></p>
+<p align="left"><iframe width="680" height="440" frameborder="0" src="https://status.cisl.ucar.edu/uss/queues_table/derecho_queues.html"></iframe></p>

--- a/docs/getting-started/acknowledging-ncar-and-cisl.md
+++ b/docs/getting-started/acknowledging-ncar-and-cisl.md
@@ -199,7 +199,7 @@ Yellowstone ARK (<http://n2t.net/ark:/85065/d7wd3xhc>) for the DOI.
 ## For CMIP Analysis Platform projects
 
 See this [CMIP Analysis Platform
-documentation](https://www2.cisl.ucar.edu/resources/cmip-analysis-platform#terms) for
+documentation](https://www.cisl.ucar.edu/resources/cmip-analysis-platform#terms) for
 how to acknowledge NSF NCAR/CISL support and for information on other
 requirements related to the use of CMIP data.
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -11,12 +11,12 @@ That’s all — really!
 
 ## Here's how to start
 
-* Check out [what we offer](https://www2.cisl.ucar.edu/computing-data) to confirm that Derecho meets your project’s needs.
+* Check out [what we offer](https://www.cisl.ucar.edu/computing-data) to confirm that Derecho meets your project’s needs.
 * Visit the [allocations](https://arc.ucar.edu/xras_submit/opportunities) page on the [ARC Portal](https://arc.ucar.edu/).
 * Make sure you are signed in, or create a new profile.
 * Click [Opportunities](https://arc.ucar.edu/xras_submit/opportunities).
 * Select a project type. You may refer to [project type descriptions](https://ncar-hpc-docs.readthedocs.io/en/latest/allocations/university-allocations/).
-* Fill out a brief request form with information about your project. 
+* Fill out a brief request form with information about your project.
 * Our team will review your request — most requests are approved within a day or two.
 * You can keep track of your request’s status through the [“My Allocations”](https://arc.ucar.edu/xras_submit/opportunities) tab.
 

--- a/docs/storage-systems/cmip-analysis-platform.md
+++ b/docs/storage-systems/cmip-analysis-platform.md
@@ -13,7 +13,7 @@ CISL’s GLADE disk storage resource.
 
     If what you need is not already on GLADE, please review the
     additional documentation in
-    [the Data Services section](https://www2.cisl.ucar.edu/computing-data/data/cmip-analysis-platform)
+    [the Data Services section](https://www.cisl.ucar.edu/computing-data/data/cmip-analysis-platform)
     of the CISL web site and submit a request.
 
 

--- a/docs/storage-systems/cmip-analysis-platform.md
+++ b/docs/storage-systems/cmip-analysis-platform.md
@@ -19,8 +19,8 @@ CISL’s GLADE disk storage resource.
 
 ## CMIP6 data sets on GLADE
 
-<iframe frameborder="1" height="1200" scrolling="yes" src="https://www.cisl.ucar.edu/uss/CMIP_AP/available_cmip6.html" width="640"></iframe></p>
+<iframe frameborder="1" height="1200" scrolling="yes" src="https://status.cisl.ucar.edu/uss/CMIP_AP/available_cmip6.html" width="640"></iframe></p>
 
 ## CMIP5 data sets on GLADE
 
-<p><iframe frameborder="1" height="1200" scrolling="yes" src="https://www.cisl.ucar.edu/uss/CMIP_AP/available_cmip5.html" width="640"></iframe></p>
+<p><iframe frameborder="1" height="1200" scrolling="yes" src="https://status.cisl.ucar.edu/uss/CMIP_AP/available_cmip5.html" width="640"></iframe></p>

--- a/docs/storage-systems/glade/campaign.md
+++ b/docs/storage-systems/glade/campaign.md
@@ -27,7 +27,7 @@ Campaign Storage**. How to make transfers to and from that collection is
 documented here: [Globus file transfers](../data-transfer/globus/index.md).
 
 How to make transfers using the command line interface also is covered
-in detail in this tutorial: [Using Globus v5 at NCAR (tutorial)](https://www2.cisl.ucar.edu/events/using-globus-v5-ncar).
+in detail in this tutorial: [Using Globus v5 at NCAR (tutorial)](https://www.cisl.ucar.edu/events/using-globus-v5-ncar).
 
 CAVEAT: The Globus interface for transferring data does not handle
 symbolic links and does not create symbolic links on a destination

--- a/docs/storage-systems/glade/index.md
+++ b/docs/storage-systems/glade/index.md
@@ -96,12 +96,12 @@ files, directories and symlinks.
 ### Status
 === "File Volume"
     <p align="left">
-        <iframe width="680" height="340" frameborder="0" src="https://www.cisl.ucar.edu/uss/glade_status/glade_status_BSK.html"></iframe>
+        <iframe width="680" height="340" frameborder="0" src="https://status.cisl.ucar.edu/uss/glade_status/glade_status_BSK.html"></iframe>
     </p>
 
 === "File Count"
     <p align="left">
-        <iframe width="680" height="340" frameborder="0" src="https://www.cisl.ucar.edu/uss/glade_status/glade_status_counts_BSK.html"></iframe>
+        <iframe width="680" height="340" frameborder="0" src="https://status.cisl.ucar.edu/uss/glade_status/glade_status_counts_BSK.html"></iframe>
     </p>
 
 ## Home space

--- a/docs/user-support/index.md
+++ b/docs/user-support/index.md
@@ -1,6 +1,6 @@
 ## Consulting
 ### Consultant on Duty
-<iframe frameborder="0" height="420" scrolling="no" src="https://www.cisl.ucar.edu/csg/cod-status/cod.html" width="100%"></iframe>
+<iframe frameborder="0" height="420" scrolling="no" src="https://status.cisl.ucar.edu/csg/cod-status/cod.html" width="100%"></iframe>
 
 ### Virtual Consulting
 


### PR DESCRIPTION
CISL has reorganized some websites to eliminate `www2.cisl.ucar.edu` in favor of `www.cisl.ucar.edu`