### PR TITLE
Remove incorrect preempt charging language

### DIFF
--- a/docs/pbs/preemption.md
+++ b/docs/pbs/preemption.md
@@ -79,9 +79,7 @@ short periods of time.
 ### Charging and allocations
 
 Jobs run in the preempt queue are charged at a queue factor of only 0.2, vs. 1.0
-for regular jobs. Jobs that do not run to
-completion because of preemption are not charged against your
-allocation.
+for jobs in the main queue with regular priority.
 
 ---
 


### PR DESCRIPTION
While the intent at one point was not to charge for preempt jobs that are in fact preempted, according to George W this has never actually been implemented. To avoid misleading users, I am striking this language until we settle on a new charging scheme for preempt.