### PR TITLE
Update largemem queue job count limits

### DIFF
--- a/docs/compute-systems/casper/starting-casper-jobs/index.md
+++ b/docs/compute-systems/casper/starting-casper-jobs/index.md
@@ -123,7 +123,7 @@ request, your submission will be classified as shown in the table.
         <pre>ncpus<=36</pre>
         <pre>ngpus=0</pre>
       </td>
-      <td>Up to 3 jobs can be run by a single user at once (consuming 50% if the <pre>largemem</pre> nodes).  5 jobs may be queued per user.</td>
+      <td>Up to 3 jobs can be run by a single user at once (consuming 50% if the largemem nodes).  5 jobs may be queued per user.</td>
     </tr>
     <tr class="even">
       <td><pre>htc</pre></td>

--- a/docs/compute-systems/casper/starting-casper-jobs/index.md
+++ b/docs/compute-systems/casper/starting-casper-jobs/index.md
@@ -123,8 +123,7 @@ request, your submission will be classified as shown in the table.
         <pre>ncpus<=36</pre>
         <pre>ngpus=0</pre>
       </td>
-      <td>Up to 5 jobs eligible for execution at any one time (more can be
-        queued)</td>
+      <td>Up to 3 jobs can be run by a single user at once (consuming 50% if the <pre>largemem</pre> nodes).  5 jobs may be queued per user.</td>
     </tr>
     <tr class="even">
       <td><pre>htc</pre></td>

--- a/docs/compute-systems/casper/starting-casper-jobs/index.md
+++ b/docs/compute-systems/casper/starting-casper-jobs/index.md
@@ -123,7 +123,7 @@ request, your submission will be classified as shown in the table.
         <pre>ncpus<=36</pre>
         <pre>ngpus=0</pre>
       </td>
-      <td>Up to 3 jobs can be run by a single user at once (consuming 50% if the largemem nodes).  5 jobs may be queued per user.</td>
+      <td>Up to 3 jobs can be run by a single user at once (consuming 50% of the largemem nodes).  5 jobs may be queued per user.</td>
     </tr>
     <tr class="even">
       <td><pre>htc</pre></td>


### PR DESCRIPTION
With the addition of more `largemem` nodes, we now allow users to run more than one job at a time.