### PR TITLE
Updates to CHAP and NSC deadlines

### DIFF
--- a/docs/allocations/chap/index.md
+++ b/docs/allocations/chap/index.md
@@ -14,7 +14,7 @@ the basis of the computational experimental design, computational
 effectiveness, and availability of computing resources.
 
 !!! note
-    The next university deadline for submitting Large Allocation Requests will be September 10, 2024.
+    The next university deadline for submitting Large Allocation Requests will be March 10, 2025.
 
 CHAP members, most of whom are from the university community, are
 appointed to three-year terms by the CISL Director. Meetings are

--- a/docs/allocations/index.md
+++ b/docs/allocations/index.md
@@ -6,7 +6,7 @@ The U.S. National Science Foundation National Center for Atmospheric Research (N
 Applications are reviewed and time is allocated according to the needs of the projects and the availability of resources. Send questions about the following allocation opportunities to alloc@ucar.edu.
 
 !!! info
-	The next university deadline for submitting Large Allocation Requests will be September 10, 2024.
+	The next university deadline for submitting Large Allocation Requests will be March 10, 2025.
 
 ## University allocations
 

--- a/docs/allocations/ncar-allocations/ncar-strategic-capability-nsc-projects.md
+++ b/docs/allocations/ncar-allocations/ncar-strategic-capability-nsc-projects.md
@@ -1,6 +1,6 @@
 # NSF NCAR Strategic Capability (NSC) projects
 
-**The next NSC submission deadline will be September 10, 2024.**
+**The next NSC submission deadline will be March 18, 2025.**
 
 NSF NCAR Strategic Capability (NSC) allocations target large-scale projects lasting 
 one year to a few years that align with NSF NCAR’s scientific priorities and 

--- a/docs/allocations/university-allocations/index.md
+++ b/docs/allocations/university-allocations/index.md
@@ -1,6 +1,6 @@
 # University allocations
 
-!!! tip "The next university deadline for submitting Large Allocation Requests will be September 10, 2024."
+!!! tip "The next university deadline for submitting Large Allocation Requests will be March 10, 2025."
 
 University use of the NSF NCAR HPC environment is intended to support Earth
 system science and related research and instruction by researchers and 

--- a/docs/allocations/university-allocations/university-large-allocation-request-preparation-instructions.md
+++ b/docs/allocations/university-allocations/university-large-allocation-request-preparation-instructions.md
@@ -1,7 +1,7 @@
 # University Large Allocation Request Preparation Instructions
 
 **The next university deadline for submitting Large Allocation Requests
-will be September 10, 2024.**
+will be March 10, 2025.**
 
 **Note:** In addition to Large Allocation Requests, CISL offers
 opportunities for NSF awardees, graduate students, and postdocs to


### PR DESCRIPTION
This update reflects the latest CHAP and NSC deadline dates, which are March 10, 2025, and March 18, 2025, respectively.