### PR TITLE
Fix for core counts new htc nodes

### DIFF
--- a/docs/compute-systems/casper/index.md
+++ b/docs/compute-systems/casper/index.md
@@ -201,6 +201,7 @@ Users already familiar with PBS and batch submission may find [Casper-specific P
         <strong>64 64-core workstation nodes</strong><br>
         768 GB 4800MHz DDR5 memory per node <br>
         1 64-Core 3.10 GHZ AMD EPYC 9554P processor per node <br>
+        62 usable cores, 2 cores reserved for Operating System <br>
         1.6TB U.3 PCIe 4.0 x4 NVMe Solid State Drive <br>
         Mellanox ConnectX®-6 100-Gb HDR100 InfiniBand Adapter <br>
       </td>

--- a/docs/compute-systems/casper/starting-casper-jobs/casper-node-types.md
+++ b/docs/compute-systems/casper/starting-casper-jobs/casper-node-types.md
@@ -19,5 +19,5 @@ The examples below also do not include options for MPI ranks or OpenMP threads b
 |                          | Intel Xeon Gold 6430     | 64    | 2.10Ghz        | 985 GB            | H100 (x4)    | 80 GB      | 2     | -l select=1:ncpus=4:mpiprocs=4:ngpus=4 -l gpu_type=h100                             |
 | High-Throughput Computing| Cascade Lake   | 36    | 2.6GHz     | 384 GB      |              |            | 62    | -l select=1:ncpus=36:cpu_type=cascadelake                             |
 |                          | Cascade Lake   | 36    | 2.3GHz     | 1500 GB     |              |            | 2     | -l select=1:ncpus=36:cpu_type=cascadelake:mem=800GB                   |
-|                          | AMD Epyc 9554P           | 64    | 3.1GHz           | 768 GB     |              |            | 64     | -l select=1:ncpus=64:cpu_type=genoa                  |
+|                          | AMD Epyc 9554P           | 62    | 3.1GHz           | 768 GB     |              |            | 64     | -l select=1:ncpus=62:cpu_type=genoa                  |
 |                          | AMD Epyc 9554P           | 64    | 3.1GHz           | 1536 GB     |              |            | 6     | -l select=1:ncpus=64:cpu_type=genoa:mem=800GB                  |


### PR DESCRIPTION
Modified to the 62 cores available in PBS since 2 CPUs are reserved for the OS on these nodes.