### PR TITLE
Change username to email

### DIFF
--- a/docs/compute-systems/cirrus/users/openbao/openbao.md
+++ b/docs/compute-systems/cirrus/users/openbao/openbao.md
@@ -11,7 +11,7 @@ CIRRUS hosts a secrets manager called OpenBao that is available to UCAR employee
 
 - Choose `kv` (key/value)
 - In the upper right choose the `Create Secret` button
-- Path for secret: `<your ucar username>/<new secret>`
+- Path for secret: `<your ucar email address>/<new secret>`
 - You can store multiple key/value pairs under each secret. 
 - Set the key to be a short description of the secret that will be used to reference it and set the value to the actual secret
 
@@ -24,7 +24,7 @@ CIRRUS hosts a secrets manager called OpenBao that is available to UCAR employee
 You may need to update your secret in order to follow best practices when managing sensitive information and keeping up with rotating them accordingly.
 
 - Login to OpenBao as defined above
-- Once in the `kv` screen list your secrets by entering `<username>/` in the view secret box
+- Once in the `kv` screen list your secrets by entering `<email_address>/` in the view secret box
 - You should see a list of your secrets
 - Edit the secret and add a new key/value token as defined above
 
@@ -52,7 +52,7 @@ spec:
     data:
         - secretKey: my-secret-value
           remoteRef:
-            key: ncote/cirrus-secrets
+            key: ncote@ucar.edu/cirrus-secrets
             property: my-secret-key
 ```
 


### PR DESCRIPTION
When using LDAP OpenBao write access was a users username. We updated from LDAP to OIDC with MFA and this now enables write access to a users email address. The docs were updated to reflect the OIDC settings.