### PR TITLE
Migrate COD iframe text to pages

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ This is the home of the user documentation for the NSF NCAR high-performance com
 Don't find what you need? Log in here to submit a help request: [NCAR Research Computing](https://rchelp.ucar.edu/).  
 You need a CIT password to submit a request. Call **303-497-2400** if you don't have one.
 
-<iframe frameborder="0" height="420" scrolling="no" src="https://status.cisl.ucar.edu/csg/cod-status/cod.html" width="100%"></iframe>
+<iframe frameborder="0" height="230" scrolling="no" src="https://status.cisl.ucar.edu/csg/cod-status/cod.html" width="650"></iframe>
 
 !!! tip
     The NSF NCAR HPC Users Group (NHUG) is a resource group for all users of NSF NCAR HPC resources.

--- a/docs/user-support/index.md
+++ b/docs/user-support/index.md
@@ -1,6 +1,12 @@
-## Consulting
-### Consultant on Duty
-<iframe frameborder="0" height="420" scrolling="no" src="https://status.cisl.ucar.edu/csg/cod-status/cod.html" width="100%"></iframe>
+## HPC Consulting Services
+
+**Hours: 8 AM - 5 PM Mountain Time; Monday - Friday**
+
+Please visit [rchelp.ucar.edu](https://rchelp.ucar.edu) or call (303)497-2400 to
+initiate a support request. You may also call the consultant on duty during
+business hours or schedule a virtual consultation below.
+
+<iframe frameborder="0" height="230" scrolling="no" src="https://status.cisl.ucar.edu/csg/cod-status/cod.html" width="650"></iframe>
 
 ### Virtual Consulting
 


### PR DESCRIPTION
This PR migrates COD iframe text to the GitHub tracked pages and resizes the COD iframe to have less bright screen in dark mode.