### PR TITLE
Enable Macros plugin: define variable values once and expand elsewhere.

### DIFF
--- a/conda.yaml
+++ b/conda.yaml
@@ -4,7 +4,7 @@
 name: mkdocs
 dependencies:
   - make
-  - python=3.9
+  - python
   - pip
   - pip:
     - jinja2>=3.0
@@ -16,6 +16,7 @@ dependencies:
     - colorama>=0.4
     - regex>=2022.4.24
     - requests>=2.26
+    - mkdocs-macros-plugin
     - mkdocs-material>=9.5.3
     - mkdocs-minify-plugin
     - mkdocs-git-revision-date-plugin

--- a/conda.yaml
+++ b/conda.yaml
@@ -4,7 +4,7 @@
 name: mkdocs
 dependencies:
   - make
-  - python
+  - python=3.12
   - pip
   - pip:
     - jinja2>=3.0

--- a/docs/allocations/chap/index.md
+++ b/docs/allocations/chap/index.md
@@ -14,7 +14,7 @@ the basis of the computational experimental design, computational
 effectiveness, and availability of computing resources.
 
 !!! note
-    The next university deadline for submitting Large Allocation Requests will be September 9, 2025.
+    The next university deadline for submitting Large Allocation Requests will be {{ next_chap_deadline }}.
 
 CHAP members, most of whom are from the university community, are
 appointed to three-year terms by the CISL Director. Meetings are

--- a/docs/allocations/index.md
+++ b/docs/allocations/index.md
@@ -6,7 +6,7 @@ The U.S. National Science Foundation National Center for Atmospheric Research (N
 Applications are reviewed and time is allocated according to the needs of the projects and the availability of resources. Send questions about the following allocation opportunities to alloc@ucar.edu.
 
 !!! info
-	The next university deadline for submitting Large Allocation Requests will be September 9, 2025.
+	The next university deadline for submitting Large Allocation Requests will be {{ next_chap_deadline }}.
 
 ## University allocations
 

--- a/docs/allocations/ncar-allocations/ncar-strategic-capability-nsc-projects.md
+++ b/docs/allocations/ncar-allocations/ncar-strategic-capability-nsc-projects.md
@@ -1,27 +1,27 @@
 # NSF NCAR Strategic Capability (NSC) projects
 
-**The next NSC submission deadline will be September 15, 2025.**
+**The next NSC submission deadline will be {{ next_nsc_deadline }}.**
 
-NSF NCAR Strategic Capability (NSC) allocations target large-scale projects lasting 
-one year to a few years that align with NSF NCAR’s scientific priorities and 
-strategic plans. These large-scale, high-priority projects are subject to review 
-of their scientific merit, strategic importance, technical readiness, and broader 
-impact. NSF NCAR researchers and computational scientists are encouraged to submit 
-requests for NSF NCAR Strategic Capability (NSC) projects to be run on the Derecho system. 
+NSF NCAR Strategic Capability (NSC) allocations target large-scale projects lasting
+one year to a few years that align with NSF NCAR’s scientific priorities and
+strategic plans. These large-scale, high-priority projects are subject to review
+of their scientific merit, strategic importance, technical readiness, and broader
+impact. NSF NCAR researchers and computational scientists are encouraged to submit
+requests for NSF NCAR Strategic Capability (NSC) projects to be run on the Derecho system.
 
-NSC proposals are accepted and reviewed every six months, in spring and fall. 
-Proposals should follow the guidance in these [instructions for preparing proposal 
+NSC proposals are accepted and reviewed every six months, in spring and fall.
+Proposals should follow the guidance in these [instructions for preparing proposal
 documents](https://ncar-hpc-docs.readthedocs.io/en/latest/allocations/university-allocations/university-large-allocation-request-preparation-instructions/),
-which apply to NSC project requests as well as to large university 
-requests. NSC projects requiring more than one year’s allocation must submit 
-continuation (renewal) proposals each year to report progress toward the 
+which apply to NSC project requests as well as to large university
+requests. NSC projects requiring more than one year’s allocation must submit
+continuation (renewal) proposals each year to report progress toward the
 project’s objectives and request the coming year’s allocation.
 
-Potential submitters should apply to the NSC opportunity that best aligns 
-with their project's anticipated timetable and readiness. In most cases, 
-a project should consider the opportunity that starts shortly **after** their 
-planned start, so that preliminary and benchmarking results can be submitted 
-as part of the NSC proposal. A project for the same or similar work can 
+Potential submitters should apply to the NSC opportunity that best aligns
+with their project's anticipated timetable and readiness. In most cases,
+a project should consider the opportunity that starts shortly **after** their
+planned start, so that preliminary and benchmarking results can be submitted
+as part of the NSC proposal. A project for the same or similar work can
 receive an allocation only once a year.
 
 To be considered for an NSC allocation, a proposed project:
@@ -33,61 +33,61 @@ To be considered for an NSC allocation, a proposed project:
 * may be linked to an agency funding award or awards separate from NSF NCAR base funding.
 
 ## NSC eligibility
-All NSC project requests must have a full or part-time regular NSF NCAR staff 
-member with an R or T appointment as project lead. In order for term employees 
-to be eligible as project leads, the period of performance of the project should 
-not extend beyond the employee's term date. Labs may choose to implement policies 
-to coordinate the submissions from the lab in each request period. Joint work 
-with university collaborators is eligible. Projects that span labs are encouraged, 
+All NSC project requests must have a full or part-time regular NSF NCAR staff
+member with an R or T appointment as project lead. In order for term employees
+to be eligible as project leads, the period of performance of the project should
+not extend beyond the employee's term date. Labs may choose to implement policies
+to coordinate the submissions from the lab in each request period. Joint work
+with university collaborators is eligible. Projects that span labs are encouraged,
 though a single project lead should be identified.
 
-NSC allocations typically have a minimum request size of 10 million core-hours 
-or 25,000 GPU-hours; exceptions can be granted for cause. Contact 
-alloc@ucar.edu to discuss a possible exception. There is no maximum size limit, 
-though in practice the review process will attempt to accommodate all meritorious 
-submissions at some level, which may require reducing the amounts awarded to 
-some projects. Consistent with the NSC objectives, NSC requests should not aggregate 
+NSC allocations typically have a minimum request size of 10 million core-hours
+or 25,000 GPU-hours; exceptions can be granted for cause. Contact
+alloc@ucar.edu to discuss a possible exception. There is no maximum size limit,
+though in practice the review process will attempt to accommodate all meritorious
+submissions at some level, which may require reducing the amounts awarded to
+some projects. Consistent with the NSC objectives, NSC requests should not aggregate
 many smaller projects out of the same lab to meet the minimum request limit.
 
-Because of the competitive nature of these allocations, labs may have chosen 
-to coordinate submissions from each lab. Potential applicants are encouraged to 
-contact their lab's or division's allocation representative before submitting a 
+Because of the competitive nature of these allocations, labs may have chosen
+to coordinate submissions from each lab. Potential applicants are encouraged to
+contact their lab's or division's allocation representative before submitting a
 request.
 
 ## NSC proposal format
-NSC requests must prepare Proposal Documents, which should follow the guidance 
-and structure for [large allocation requests for universities](https://ncar-hpc-docs.readthedocs.io/en/latest/allocations/university-allocations/university-large-allocation-request-preparation-instructions/). 
+NSC requests must prepare Proposal Documents, which should follow the guidance
+and structure for [large allocation requests for universities](https://ncar-hpc-docs.readthedocs.io/en/latest/allocations/university-allocations/university-large-allocation-request-preparation-instructions/).
 Notably, NSC requests must include a five-page summary along with relevant supporting documentation.
 
-For those projects requiring more than one year’s allocation, a continuation request 
-will need to be submitted as part of the next year’s NSC request and review process. 
-The continuation request should include a short progress write-up according to the 
+For those projects requiring more than one year’s allocation, a continuation request
+will need to be submitted as part of the next year’s NSC request and review process.
+The continuation request should include a short progress write-up according to the
 instructions for large allocation requests.
 
-!!! info 
-          Long-term storage plans for NSC project data in Campaign Storage should be coordinated with the requester's lab(s). 
+!!! info
+          Long-term storage plans for NSC project data in Campaign Storage should be coordinated with the requester's lab(s).
           The data management plan section in your NSC request document should describe the arrangements made with your lab.
 
-## Review process and schedule 
-NSC requests are reviewed twice per year. Projects arising too late for NSC 
-consideration will either need to wait, identify bridging allocations from NSF NCAR labs, 
-or apply for startup allocations via the NSF NCAR Director’s Reserve. Such NSC pre-awards 
+## Review process and schedule
+NSC requests are reviewed twice per year. Projects arising too late for NSC
+consideration will either need to wait, identify bridging allocations from NSF NCAR labs,
+or apply for startup allocations via the NSF NCAR Director’s Reserve. Such NSC pre-awards
 must satisfy the criteria for a Director’s Reserve award.
 
-NSC requests are reviewed by a panel of computational scientists composed of 
-representatives of each NSF NCAR lab and program who are appointed by the lab and program 
-directors. This panel evaluates proposals according to the [three criteria used by 
-the CHAP](https://ncar-hpc-docs.readthedocs.io/en/latest/allocations/chap/chap-allocation-review-criteria/) 
-in its evaluation of large university requests – the effectiveness of the 
-methodology, the appropriateness of the research plan, and the efficiency of resource 
-use. The technical readiness description also provides input into this aspect of 
+NSC requests are reviewed by a panel of computational scientists composed of
+representatives of each NSF NCAR lab and program who are appointed by the lab and program
+directors. This panel evaluates proposals according to the [three criteria used by
+the CHAP](https://ncar-hpc-docs.readthedocs.io/en/latest/allocations/chap/chap-allocation-review-criteria/)
+in its evaluation of large university requests – the effectiveness of the
+methodology, the appropriateness of the research plan, and the efficiency of resource
+use. The technical readiness description also provides input into this aspect of
 the evaluation.
 
-The relationship between the proposed projects and NSF NCAR’s strategic priorities 
-is assessed by the NSF NCAR Directorate. This strategic assessment informs the 
-priority ranking for NSC requests, which may be used when proposal requests 
+The relationship between the proposed projects and NSF NCAR’s strategic priorities
+is assessed by the NSF NCAR Directorate. This strategic assessment informs the
+priority ranking for NSC requests, which may be used when proposal requests
 exceed available resources to defer the start of some projects.
 
-Should any awarded project encounter issues that require it to stop work or 
-be unable to complete its proposed work, additional allocation awards may be 
+Should any awarded project encounter issues that require it to stop work or
+be unable to complete its proposed work, additional allocation awards may be
 made to unawarded requests in order of priority rank and as resource availability permits.

--- a/docs/allocations/university-allocations/index.md
+++ b/docs/allocations/university-allocations/index.md
@@ -1,6 +1,6 @@
 # University allocations
 
-!!! tip "The next university deadline for submitting Large Allocation Requests will be September 9, 2025."
+!!! tip "The next university deadline for submitting Large Allocation Requests will be {{ next_chap_deadline }}."
 
 University use of the NSF NCAR HPC environment is intended to support Earth
 system science and related research and instruction by researchers and

--- a/docs/allocations/university-allocations/university-large-allocation-request-preparation-instructions.md
+++ b/docs/allocations/university-allocations/university-large-allocation-request-preparation-instructions.md
@@ -1,7 +1,7 @@
 # University Large Allocation Request Preparation Instructions
 
 **The next university deadline for submitting Large Allocation Requests
-will be September 9, 2025.**
+will be {{ next_chap_deadline }}.**
 
 **Note:** In addition to Large Allocation Requests, CISL offers
 opportunities for NSF awardees, graduate students, and postdocs to

--- a/docs/compute-systems/additional-resources/cron.md
+++ b/docs/compute-systems/additional-resources/cron.md
@@ -34,7 +34,7 @@ Typical usage of this `cron` resource is:
 
 
 ### Accessing PBS commands
-The typical [PBS commands](../../pbs/index.md) ``qsub`, `qstat`, etc... are available by default, and users can access both Derecho and Casper PBS queues from the `cron` system provided that PBS server names are appended to the usual queue specifications (similar to the usual PBS cross-submission described [here](../../pbs/index.md#submitting-a-job-to-a-peer-system)):
+The typical [PBS commands](../../pbs/index.md) ``qsub`, `qstat`, etc... are available by default, and users can access both Derecho and Casper PBS queues from the `cron` system provided that PBS server names are appended to the usual queue specifications (similar to the usual PBS cross-submission described [here](../../pbs/peer-scheduling.md)):
 === "Derecho Access"
     Command-line specification of a Derecho queue:
     ```console
@@ -190,7 +190,7 @@ which can be useful in the future; particularly many years from now if `cron` st
 	---8<--- "https://raw.githubusercontent.com/NCAR/hpc-demos/main/cron/PBS_submissions/cron_driver.sh"
 	```
     The script begins by establishing an exclusive file lock, performing some logging, and then moving to the intended run directory.
-    The first job (`prep_job.pbs`) will create a file called `INPUT_DATA` which is used by the second job (`run_model.pbs`).  Because the second job depends on the first, we submit the second using a [PBS job dependency](../../pbs/index.md#job-dependencies).
+    The first job (`prep_job.pbs`) will create a file called `INPUT_DATA` which is used by the second job (`run_model.pbs`).  Because the second job depends on the first, we submit the second using a [PBS job dependency](../../pbs/job-dependencies.md).
 
     We also remove the `INPUT_DATA` at the beginning of the script - since it *should* be created by `prep_job.pbs`, we want to make sure that step functioned as intended.  In this way if `INPUT_DATA` exists when we execute `run_model.pbs` it can only be because the preceding step ran successfully - and our `INPUT_DATA` is not stale.
 

--- a/docs/compute-systems/cirrus/guides/07-secret-manager/openbao.md
+++ b/docs/compute-systems/cirrus/guides/07-secret-manager/openbao.md
@@ -1,3 +1,8 @@
+---
+render_macros: false
+---
+<!-- the above suppresses MkDocs macros parsing - conflicts with YAML example below -->
+
 # Secret Manager
 
 CIRRUS hosts a secrets management service called **OpenBao**, available to UCAR employees via a secure Web UI. It allows you to store sensitive data such as API tokens, credentials, and configuration variables in a central, encrypted location.
@@ -20,7 +25,7 @@ CIRRUS hosts a secrets management service called **OpenBao**, available to UCAR 
 
 6. Click the **Create Secret** button in the upper right.
 
-7. For the **Path**, enter:  
+7. For the **Path**, enter:
    `<your ucar email address>/<new secret>`
 
 8. Under that secret path, add key/value pairs:

--- a/docs/pbs/peer-scheduling.md
+++ b/docs/pbs/peer-scheduling.md
@@ -61,7 +61,7 @@ qstat main@desched1
 
 ## Creating dependencies between peer-scheduled jobs
 
-Creating [job dependencies](#job-dependencies) between submissions on peer servers is
+Creating [job dependencies](job-dependencies.md) between submissions on peer servers is
 straightforward; there is nothing unique about this workflow in PBS. As
 with all jobs, pay close attention to specifying the destination server
 in your queue designations. The job IDs returned by PBS include the

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,7 +31,7 @@ validation:
 # ------------------------------------
 # ----------- content ----------------
 # ------------------------------------
-nav: 
+nav:
   - Getting Started:
     - getting-started/index.md
     - User Responsibilities: getting-started/user-responsibilities.md
@@ -91,17 +91,17 @@ nav:
       - Interact with CIRRUS team:
             - compute-systems/cirrus/guides/02-interact-with-cirrus-team/agile.md
             - compute-systems/cirrus/guides/02-interact-with-cirrus-team/create-tickets.md
-      - Deploying Applications: 
+      - Deploying Applications:
             - compute-systems/cirrus/guides/03-deploying-applications/containerize.md
             - compute-systems/cirrus/guides/03-deploying-applications/additions.md
-      - Container Registry: 
+      - Container Registry:
         - compute-systems/cirrus/guides/04-container-registry/index.md
         - Image Management: compute-systems/cirrus/guides/04-container-registry/image-mgmt.md
         - Vulnerability Scanner: compute-systems/cirrus/guides/04-container-registry/vulnerability-scan.md
       - GitHub Actions:
         - compute-systems/cirrus/guides/05-github-actions/best-practices.md
         - compute-systems/cirrus/guides/05-github-actions/scale-sets.md
-      - Jupyter on CIRRUS: 
+      - Jupyter on CIRRUS:
         - compute-systems/cirrus/guides/06-jupyter-on-cirrus/jupyterhub.md
         - Conda Environments: compute-systems/cirrus/guides/06-jupyter-on-cirrus/conda-envs.md
         - GPU Use: compute-systems/cirrus/guides/06-jupyter-on-cirrus/jhub-gpu.md
@@ -202,7 +202,7 @@ nav:
   - NCAR User Group (NHUG):
     - nhug/index.md
 
-  - Contributing to the Documentation: 
+  - Contributing to the Documentation:
     - contributing/index.md
 
 # ------------------------------------
@@ -305,6 +305,7 @@ plugins:
         - custom-skip-class-name
       auto_caption: false
       caption_position: bottom
+  - macros
   - minify:
       minify_html: true
   - open-in-new-tab
@@ -335,6 +336,8 @@ plugins:
 # -- configuration - extras
 # ------------------------------------
 extra:
+  next_chap_deadline: early March 2026
+  next_nsc_deadline: mid March 2026
   analytics:
     provider: google
     property: G-RZLJ37D0K6


### PR DESCRIPTION
Allows for the following, for example:
`mkdocs.yml`:
```yaml
# ------------------------------------
# -- configuration - extras
# ------------------------------------
extra:
  next_chap_deadline: early March 2026
  next_nsc_deadline: mid March 2026
  analytics:
    provider: google
    property: G-RZLJ37D0K6
[...]
```
Then 
```pre
docs/allocations/chap/index.md:    The next university deadline for submitting Large Allocation Requests will be {{ next_chap_deadline }}.
docs/allocations/index.md:      The next university deadline for submitting Large Allocation Requests will be {{ next_chap_deadline }}.
docs/allocations/university-allocations/index.md:!!! tip "The next university deadline for submitting Large Allocation Requests will be {{ next_chap_deadline }}."
docs/allocations/university-allocations/university-large-allocation-request-preparation-instructions.md:will be {{ next_chap_deadline }}.**
```