### PR TITLE
Unpin workflow Python since it is specified in the env

### DIFF
--- a/.github/workflows/pr_preview.yml
+++ b/.github/workflows/pr_preview.yml
@@ -23,7 +23,6 @@ jobs:
         with:
           activate-environment: mkdocs
           environment-file: conda.yaml
-          python-version: 3.9
           auto-activate-base: false
 
       - name: Interrogate Environment


### PR DESCRIPTION
This change unpins Python from 3.9 in the `pr_preview` workflow. The workflow was failing since the `conda.yaml` environment was repinned from 3.9 to 3.12.

Rather than repin the workflow to 3.12 as well, I propose letting it float (the `setup-miniconda` action will use the latest Python by default, but this doesn't matter since it will override that with the Python version specified in our environment YAML).