### PR TITLE
Cirrus Add an index for deploying applications

### DIFF
--- a/docs/compute-systems/cirrus/guides/01-intro/index.md
+++ b/docs/compute-systems/cirrus/guides/01-intro/index.md
@@ -63,7 +63,7 @@ Learn how to work with the CIRRUS team and get support.
 - **[agile methodology](../02-interact-with-cirrus-team/agile.md)**<br/>How the team works and manages requests. Use this to understand our development process.
 - **[create tickets](../02-interact-with-cirrus-team/create-tickets.md)**<br/>How to submit requests and report issues. Use when you need help or want to request services.
 
-### **Deploying Applications**
+### **[Deploying Applications](../03-deploying-applications/)**
 Everything you need to containerize and deploy applications on CIRRUS.
 
 - **[create containers](../03-deploying-applications/containerize.md)**<br/>Step-by-step containerization guide. Perfect if you're new to containers or Docker.

--- a/docs/compute-systems/cirrus/guides/03-deploying-applications/index.md
+++ b/docs/compute-systems/cirrus/guides/03-deploying-applications/index.md
@@ -53,3 +53,8 @@ GitOps is a deployment methodology where the desired state of workloads is defin
 Argo CD is the continuous delivery (CD) tool CIRRUS uses to implement GitOps. Argo CD continuously watches Git repositories for any changes between what's currently running, and what's defined in Git. If they become out of sync, Argo CD can automatically update the running workload to match the Git state.
 
 ---
+
+## What's Next
+
+- [Creating a container image](../03-deploying-applications/containerize.md)
+- [Creating a Helm chart](../03-deploying-applications/additions.md)

--- a/docs/compute-systems/cirrus/guides/03-deploying-applications/index.md
+++ b/docs/compute-systems/cirrus/guides/03-deploying-applications/index.md
@@ -9,6 +9,9 @@ CIRRUS is a cloud-native platform built on top of Kubernetes. It utilizes GitOps
  - **A container image** to run the workloads
  - A Git repository containing a collection of YAML files known as **a Helm chart**
 
+!!! note
+    The Helm chart defines how CIRRUS deploys your workload, including which container images to run.
+
 ---
 
 ## Key Concepts

--- a/docs/compute-systems/cirrus/guides/03-deploying-applications/index.md
+++ b/docs/compute-systems/cirrus/guides/03-deploying-applications/index.md
@@ -1,0 +1,34 @@
+# Deploying Applications
+
+CIRRUS is a cloud-native platform built on top of Kubernetes. It utilizes GitOps and Argo CD to deploy and manage workloads defined by code stored in Git.
+
+## Requirements
+
+ - **A container image** to run the workloads
+ - A Git repository containing a collection of YAML files known as **a Helm chart**
+
+## Key Concepts
+
+### Containers
+
+Containers package code with all the requirements to run it in a single image that is small and portable. It will run the same on any hardware with a container engine. 
+
+### Kubernetes (K8s)
+
+Kubernetes (K8s) is a container orchestration platform. It handles scheduling and running containers across servers in the cluster.
+
+### Helm charts
+
+Helm charts are collections of YAML files organized in a specific structure that define different Kubernetes objects. 
+
+### Cloud-native
+
+The cloud is what your workload runs on. Cloud-native is building a workload designed to run in any cloud environment.
+
+### GitOps
+
+GitOps is a deployment methodology where the desired state of workloads is defined entirely in Git. The Git repository is a single source of truth for the running state of the workload. 
+
+### Argo CD
+
+Argo CD is the continuous delivery (CD) tool CIRRUS uses to implement GitOps. Argo CD continuously watches Git repositories for any changes between what's currently running, and what's defined in Git. If they become out of sync, Argo CD can automatically update the running workload to match the Git state.

--- a/docs/compute-systems/cirrus/guides/03-deploying-applications/index.md
+++ b/docs/compute-systems/cirrus/guides/03-deploying-applications/index.md
@@ -2,33 +2,51 @@
 
 CIRRUS is a cloud-native platform built on top of Kubernetes. It utilizes GitOps and Argo CD to deploy and manage workloads defined by code stored in Git.
 
+---
+
 ## Requirements
 
  - **A container image** to run the workloads
  - A Git repository containing a collection of YAML files known as **a Helm chart**
 
+---
+
 ## Key Concepts
+
+---
 
 ### Containers
 
 Containers package code with all the requirements to run it in a single image that is small and portable. It will run the same on any hardware with a container engine. 
 
+---
+
 ### Kubernetes (K8s)
 
 Kubernetes (K8s) is a container orchestration platform. It handles scheduling and running containers across servers in the cluster.
+
+---
 
 ### Helm charts
 
 Helm charts are collections of YAML files organized in a specific structure that define different Kubernetes objects. 
 
+---
+
 ### Cloud-native
 
 The cloud is what your workload runs on. Cloud-native is building a workload designed to run in any cloud environment.
+
+---
 
 ### GitOps
 
 GitOps is a deployment methodology where the desired state of workloads is defined entirely in Git. The Git repository is a single source of truth for the running state of the workload. 
 
+---
+
 ### Argo CD
 
 Argo CD is the continuous delivery (CD) tool CIRRUS uses to implement GitOps. Argo CD continuously watches Git repositories for any changes between what's currently running, and what's defined in Git. If they become out of sync, Argo CD can automatically update the running workload to match the Git state.
+
+---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,7 +91,8 @@ nav:
       - Interact with CIRRUS team:
             - compute-systems/cirrus/guides/02-interact-with-cirrus-team/agile.md
             - compute-systems/cirrus/guides/02-interact-with-cirrus-team/create-tickets.md
-      - Deploying Applications: compute-systems/cirrus/guides/03-deploying-applications/index.md
+      - Deploying Applications: 
+            - compute-systems/cirrus/guides/03-deploying-applications/index.md
             - compute-systems/cirrus/guides/03-deploying-applications/containerize.md
             - compute-systems/cirrus/guides/03-deploying-applications/additions.md
             - compute-systems/cirrus/guides/03-deploying-applications/alerts.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,7 +91,7 @@ nav:
       - Interact with CIRRUS team:
             - compute-systems/cirrus/guides/02-interact-with-cirrus-team/agile.md
             - compute-systems/cirrus/guides/02-interact-with-cirrus-team/create-tickets.md
-      - Deploying Applications:
+      - Deploying Applications: compute-systems/cirrus/guides/03-deploying-applications/index.md
             - compute-systems/cirrus/guides/03-deploying-applications/containerize.md
             - compute-systems/cirrus/guides/03-deploying-applications/additions.md
             - compute-systems/cirrus/guides/03-deploying-applications/alerts.md


### PR DESCRIPTION
I wanted to make it more clear that to add applications to CIRRUS that you need a git repository with a helm chart in it. That helm chart can use custom images. 